### PR TITLE
fix unauthorized_page issue

### DIFF
--- a/core/components/zoomx/src/RequestHandler.php
+++ b/core/components/zoomx/src/RequestHandler.php
@@ -145,7 +145,14 @@ abstract class RequestHandler
                     return null;
                 }
                 if (!$resource->checkPolicy('view')) {
-                    abortx(403);
+                    $pageId = $this->modx->getOption('unauthorized_page');
+                    $resource = $this->modx->getObject('modResource', $pageId);
+
+                    if (!$resource instanceof modResource){
+                        abortx(403);
+                    }
+
+                    redirectx($resource->get('alias'));
                 }
                 if ($tvs = $resource->getMany('TemplateVars', 'all')) {
                     /** @var \modTemplateVar $tv */


### PR DESCRIPTION
If you create an access policy through the built-in ACL, then there is no way to return the page that is specified by default as unauthorized.

What I did
1. If the resource does not exist, an exception with a 403 code will be returned (as it is now)
2. If the resource exists, then I will redirect to this page (unfortunately with code 200)

Perhaps you have other ideas on how to fix it - I am ready to listen and help with the implementation